### PR TITLE
Add extra_headers setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1569,6 +1569,12 @@ EOT
       :default    => lambda { Puppet::Settings.domain_fact },
       :desc       => "The domain which will be queried to find the SRV records of servers to use.",
     },
+    :http_extra_headers => {
+      :default    => [],
+      :type       => :http_extra_headers,
+      :desc       => "The list of extra headers that will be sent with every HTTP request.
+        The header definition consists of a name and a value separated by a colon."
+    },
     :ignoreschedules => {
       :default    => false,
       :type       => :boolean,

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -3,6 +3,7 @@ require 'puppet/ssl/host'
 require 'puppet/ssl/configuration'
 require 'puppet/ssl/validator'
 require 'puppet/network/http'
+require 'puppet/util/connection'
 require 'uri'
 require 'date'
 require 'time'
@@ -176,6 +177,7 @@ module Puppet::Network::HTTP
 
         with_connection(current_site) do |connection|
           apply_options_to(current_request, options)
+          Puppet::Util::Connection.add_extra_headers(current_request)
 
           current_response = execute_request(connection, current_request)
 

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -30,6 +30,7 @@ class Puppet::Settings
   require 'puppet/settings/value_translator'
   require 'puppet/settings/environment_conf'
   require 'puppet/settings/server_list_setting'
+  require 'puppet/settings/http_extra_headers_setting'
   require 'puppet/settings/certificate_revocation_setting'
 
   # local reference for convenience
@@ -678,6 +679,7 @@ class Puppet::Settings
       :priority   => PrioritySetting,
       :autosign   => AutosignSetting,
       :server_list => ServerListSetting,
+      :http_extra_headers => HttpExtraHeadersSetting,
       :certificate_revocation => CertificateRevocationSetting
   }
 

--- a/lib/puppet/settings/http_extra_headers_setting.rb
+++ b/lib/puppet/settings/http_extra_headers_setting.rb
@@ -1,0 +1,20 @@
+class Puppet::Settings::HttpExtraHeadersSetting < Puppet::Settings::ArraySetting
+
+  def type
+    :http_extra_headers
+  end
+
+  def munge(value)
+    headers = super
+    headers.map! { |header|
+      case header
+      when String
+        header.split(':')
+      when Array
+        header
+      else
+        raise ArgumentError, _("Expected an Array of String, got a %{klass}") % { klass: value.class }
+      end
+    }
+  end
+end

--- a/lib/puppet/util/connection.rb
+++ b/lib/puppet/util/connection.rb
@@ -1,0 +1,23 @@
+require 'puppet'
+require 'puppet/util/warnings'
+
+module Puppet::Util
+  module Connection
+    extend Puppet::Util::Warnings
+
+    # Adds extra headers to a given request if http_extra_headers option was set.
+    # @param [Hash] request The request to be modified
+    # @return [Hash] the modified request
+    def self.add_extra_headers(request)
+      Puppet[:http_extra_headers].each do |header, value|
+        if request.key?(header)
+          Puppet.warning(_('Ignoring extra header "%{header}" as it was previously set.') %
+                         {header: header})
+        else
+          request[header] = value
+        end
+      end
+      request
+    end
+  end
+end

--- a/lib/puppet/util/http_proxy.rb
+++ b/lib/puppet/util/http_proxy.rb
@@ -1,6 +1,7 @@
 require 'uri'
 require 'openssl'
 require 'puppet/network/http'
+require 'puppet/util/connection'
 
 module Puppet::Util::HttpProxy
   def self.proxy(uri)
@@ -180,6 +181,7 @@ module Puppet::Util::HttpProxy
       if Puppet.features.zlib?
         headers.merge!({"Accept-Encoding" => Puppet::Network::HTTP::Compression::ACCEPT_ENCODING})
       end
+      Puppet::Util::Connection.add_extra_headers(headers)
 
       response = proxy.send(:head, current_uri.path, headers)
 

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -393,4 +393,25 @@ describe Puppet::Network::HTTP::Connection do
 
     subject.get('/path')
   end
+
+  it "sets extra headers specified in http_extra_headers" do
+    Puppet[:http_extra_headers] = ["foo:bar"]
+
+    Net::HTTP.any_instance.expects(:request).with do |request|
+      expect(request['foo']).to eq("bar")
+    end.returns(httpok)
+
+    subject.get('/path')
+  end
+
+  it "doesn't change headers already specified" do
+    puppet_ua = "Puppet/#{Puppet.version} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})"
+    Puppet[:http_extra_headers] = ["User-Agent:foo"]
+
+    Net::HTTP.any_instance.expects(:request).with do |request|
+      expect(request['User-Agent']).to eq(puppet_ua)
+    end.returns(httpok)
+
+    subject.get('/path')
+  end
 end

--- a/spec/unit/util/http_proxy_spec.rb
+++ b/spec/unit/util/http_proxy_spec.rb
@@ -232,6 +232,33 @@ describe Puppet::Util::HttpProxy do
       subject.request_with_redirects(dest, :get, 0)
     end
 
+    it 'add extra headers specified in http_extra_headers' do
+      Puppet[:http_extra_headers] = ["foo:bar", "baz:qux"]
+
+      Net::HTTP.any_instance.stubs(:head).returns(http_ok)
+      Net::HTTP.any_instance.expects(:get).with do |_, headers|
+        expect(headers)
+          .to include({'foo' => 'bar',
+                     'baz' => 'qux'})
+      end.returns(http_ok)
+
+      subject.request_with_redirects(dest, :get, 0)
+    end
+
+    it "doesn't change headers already specified" do
+      Puppet[:http_extra_headers] = ["User-Agent:foo"]
+
+      Net::HTTP.any_instance.stubs(:head).returns(http_ok)
+      Net::HTTP.any_instance.expects(:get).with do |_, headers|
+        expect(headers)
+          .to include({'Accept' => '*/*',
+                     'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'User-Agent' => /Puppet/})
+      end.returns(http_ok)
+
+      subject.request_with_redirects(dest, :get, 0)
+    end
+
     it 'can return a compressed response body' do
       Net::HTTP.any_instance.stubs(:head).returns(http_ok)
 


### PR DESCRIPTION
This new setting allows to pass a list of headers in every HTTP
request. These headers can be used, for example, to redirect the
traffic to specific Puppet Servers in an HAProxy.

Requested upstream in PUP-9566.