### PR TITLE
Do not process Node definitions

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -488,6 +488,7 @@ class Puppet::Parser::Compiler
 
   # If ast nodes are enabled, then see if we can find and evaluate one.
   def evaluate_ast_node
+    return
     krt = environment.known_resource_types
     return unless krt.nodes? #ast_nodes?
 


### PR DESCRIPTION
There seems to be a bug allowing default Node definitions to be leaked
across catalogs. If a node A has a:

```
  node default {
    resources here
  }
```

in the catalog and a thread compiles for it, a node B coming behind will
pick up this definition which is bad in a "shared master" environment.
Surprisingly enough this only happens during the immediate following
compilation to A's. If B requests yet another catalog it will be clean.

In our environment (where there's an ENC) we don't want people to even
use Node declarations so as a workaround for this bug we're now
completely ignoring these at the time of walking the AST.